### PR TITLE
Do not track cscope files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -274,3 +274,6 @@ packages/smooth_app/ios/Runner/val.lproj/InfoPlist.strings
 packages/smooth_app/ios/Runner/vec.lproj/InfoPlist.strings
 packages/smooth_app/ios/Runner/vls.lproj/InfoPlist.strings
 packages/smooth_app/ios/Runner/zea.lproj/InfoPlist.strings
+
+# Custom
+cscope*


### PR DESCRIPTION
Update `.gitignore` to NOT track cscope files.