### PR TITLE
APP-37 Wrapped the SummaryCard in a SizedBox to add a fixed height

### DIFF
--- a/packages/smooth_app/lib/pages/onboarding/preferences_page.dart
+++ b/packages/smooth_app/lib/pages/onboarding/preferences_page.dart
@@ -102,13 +102,16 @@ class _HelperState extends State<_Helper> {
           start: LARGE_SPACE,
           end: LARGE_SPACE,
         ),
-        child: SummaryCard(
-          widget.product,
-          productPreferences,
-          isFullVersion: true,
-          isRemovable: false,
-          isSettingVisible: false,
-          isProductEditable: false,
+        child: SizedBox(
+          height: MediaQuery.of(context).size.height * 0.6,
+          child: SummaryCard(
+            widget.product,
+            productPreferences,
+            isFullVersion: true,
+            isRemovable: false,
+            isSettingVisible: false,
+            isProductEditable: false,
+          ),
         ),
       ),
     ];


### PR DESCRIPTION
The problem was when building the PreferencesPage. In the building of a SummaryCard widget, the set height was infinite, and Flutter threw exceptions because of this.
I’ve wrapped the SummaryCard in a SizedBox so that we could show it and if the phone display is too small, the content could be scrolled.